### PR TITLE
Fix GitHub package link

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/huhulacolle/detect-social-network.git"
+    "url": "git+https://github.com/huhulacolle/cours-package.git"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The GitHub package link in the repository configuration has been fixed to point to the correct repository.